### PR TITLE
Add excluded categories feature.

### DIFF
--- a/CherryPick_Config.cs
+++ b/CherryPick_Config.cs
@@ -22,4 +22,8 @@ public partial class CherryPick : ResoniteMod
 
     [AutoRegisterConfigKey]
     public static ModConfigurationKey<bool> ClearFocus = new("Clear focus", "When checked, the search buttons will clear the focus of the search bar.", () => true);
+
+    [AutoRegisterConfigKey]
+    public static ModConfigurationKey<string> UserExcludedCategories = new("Excluded categories", "Excludes specific categories from being searched into by path. Separate entries by semicolon. Search will work when started inside them", () => "/ProtoFlux, /Example/Test");
+
 }

--- a/CherryPicker.cs
+++ b/CherryPicker.cs
@@ -67,7 +67,9 @@ public class CherryPicker(Slot searchRoot, Slot componentUIRoot, ButtonEventHand
 
         string[] splitQuery = query.Split(' ');
 
-        
+        string userexcludedcategories = Config!.GetValue(CherryPick.UserExcludedCategories).ToLower();
+        string[] UserExcludedCategories = userexcludedcategories.Replace(" ", null).Split(',');
+
 
         // The for loops are a bit hot and can cause minor
         // hitches if care isn't taken. Avoiding branch logic if possible
@@ -78,12 +80,15 @@ public class CherryPicker(Slot searchRoot, Slot componentUIRoot, ButtonEventHand
             for (int i = 0; i < workerCount; i++)
             {
                 WorkerDetails worker = details[i];
-                float ratio = MatchRatioInsensitive(worker.LowerName, splitQuery);
+                if (!UserExcludedCategories.Any(worker.Path.ToLower().Contains))
+                {
+                    float ratio = MatchRatioInsensitive(worker.LowerName, splitQuery);
 
-                _results.Add(ratio, worker);
-                int detailCount = _results.Count;
+                    _results.Add(ratio, worker);
+                    int detailCount = _results.Count;
 
-                _results.RemoveAt(detailCount - 1);
+                    _results.RemoveAt(detailCount - 1);
+                }
             }
         }
         else
@@ -92,12 +97,15 @@ public class CherryPicker(Slot searchRoot, Slot componentUIRoot, ButtonEventHand
             for (int i = 0; i < workerCount; i++)
             {
                 WorkerDetails worker = details[i];
-                float ratio = worker.Path.StartsWith(searchScope) ? MatchRatioInsensitive(worker.LowerName, splitQuery) : 0f;
+                if (!UserExcludedCategories.Any(worker.Path.ToLower().Contains))
+                {
+                    float ratio = worker.Path.StartsWith(searchScope) ? MatchRatioInsensitive(worker.LowerName, splitQuery) : 0f;
 
-                _results.Add(ratio, worker);
-                int detailCount = _results.Count;
+                    _results.Add(ratio, worker);
+                    int detailCount = _results.Count;
 
-                _results.RemoveAt(detailCount - 1);
+                    _results.RemoveAt(detailCount - 1);
+                }
             }
         }
         


### PR DESCRIPTION
Excludes specific categories from being searched into by path. Separate entries by semicolon. Search will work when started inside them.
![Screenshot (77)](https://github.com/user-attachments/assets/9c98c836-325b-4f45-8f5a-96750b752192)
![Screenshot (76)](https://github.com/user-attachments/assets/b51e2ffb-f99e-4e00-9570-24b93bcd2d2c)