### PR TITLE
Add the ability to remove ProtoFlux components from component search

### DIFF
--- a/CherryPick_Config.cs
+++ b/CherryPick_Config.cs
@@ -22,4 +22,7 @@ public partial class CherryPick : ResoniteMod
 
     [AutoRegisterConfigKey]
     public static ModConfigurationKey<bool> ClearFocus = new("Clear focus", "When checked, the search buttons will clear the focus of the search bar.", () => true);
+
+    [AutoRegisterConfigKey]
+    public static ModConfigurationKey<bool> ShowProtofluxInComponentSearch = new("Show Protoflux in Component Search", "When checked, Protoflux components will be shown in the component search results", () => false);
 }


### PR DESCRIPTION
ProtoFlux components are not useful in the generic component search (they should be created in the world with the ProtoFlux tool), but since they are just normal components, they appear in the search results. This change will add an extra filter to the weighted search algorithm to downrank components that start with the ProtoFlux path, if we're in a general component search (no search scope).

This change can be disabled with a new config option, if for whatever reason you want to see ProtoFlux components in the search results.

## Notes

Although normally I'd prefer to handle this in a more generic fashion, realistically the only filtering that we'll want to implement will be removing ProtoFlux nodes from the component search, and care was taken to keep the work in the weighting hotloop to a minimum.